### PR TITLE
Fix permissions of CIVET install so unprivileged Singularity users can run the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN ["bash", "install.sh"]
 # clean up build files to reduce image size
 WORKDIR /opt/CIVET/Linux-x86_64
 RUN ["rm", "-r", "SRC", "building", "info", "man"]
+RUN ["chmod", "--recursive", "u+rX,g+rX,o+rX", "/opt/CIVET" ]
 
 # multi-stage build
 FROM base


### PR DESCRIPTION
Testing a singularity deployment of the docker container, I found we can't actually run the container:
```
> singularity build civet_2.1.1.img docker://mcin/civet:2.1.1
INFO:    Starting build...
Getting image source signatures
Copying blob 2746a4a261c9 done
Copying blob 4c1d20cdee96 done
Copying blob 0d3160e1d0de done
Copying blob c8e37668deea done
Copying blob a34007e3ec19 done
Copying blob 3348fdd254cc done
Copying blob c59f168518bf done
Copying blob de8600d7ff63 done
Copying config 66d3cdf03c done
Writing manifest to image destination
Storing signatures
2020/02/18 10:42:17  info unpack layer: sha256:2746a4a261c9e18bfd7ff0429c18fd7522acc14fa4c7ec8ab37ba5ebaadbc584
2020/02/18 10:42:20  info unpack layer: sha256:4c1d20cdee96111c8acf1858b62655a37ce81ae48648993542b7ac363ac5c0e5
2020/02/18 10:42:20  info unpack layer: sha256:0d3160e1d0de4061b5b32ee09af687b898921d36ed9556df5910ddc3104449cd
2020/02/18 10:42:20  info unpack layer: sha256:c8e37668deea784f47c8726d934adc12b8d20a2b1c50b0b0c18cb62771cd3684
2020/02/18 10:42:20  info unpack layer: sha256:a34007e3ec1929cd131f2a6c369233ec713be68efc03268c2c3f18a6781f9ecf
2020/02/18 10:42:20  info unpack layer: sha256:3348fdd254cc5b650374e5410be5d536a51ac22dc586d825421ebcb69344fabe
2020/02/18 10:42:42  info unpack layer: sha256:c59f168518bffb3e96ab38074b0c2bb539139ca4ce3a6a222ceca7be8ed210d1
2020/02/18 10:42:42  info unpack layer: sha256:de8600d7ff639e8c4e4fc288787d2a085b05bf77aaa72a2d617f08899a95c335
INFO:    Creating SIF file...
INFO:    Build complete: civet_2.1.1.img
> singularity run civet_2.1.1.img
/.singularity.d/runscript: 39: exec: /opt/CIVET/Linux-x86_64/CIVET-2.1.1/CIVET_Processing_Pipeline: Permission denied
```

Turns out that the CIVET install is root:root and missing "other" permission:
```
> singularity exec civet_2.1.1.img ls -l /opt/CIVET/Linux-x86_64
total 4
drwxr-x---  4 root root  509 Jan 10 13:41 CIVET-2.1.1
drwxrwxr-x  2 root root 8692 Jan 10 13:30 bin
drwxr-xr-x  3 root root   38 Jan 10 13:17 doc
drwxr-x---  3 root root   34 Jan 10 13:11 etc
drwxr-x---  8 root root 1670 Jan 10 13:25 include
-rw-r-----  1 root root 1581 Jan 10 13:40 init.csh
-rw-r-----  1 root root 1582 Jan 10 13:40 init.sh
drwxr-x---  4 root root 1068 Jan 10 13:27 lib
drwxr-x---  7 root root  185 Jan 10 13:00 perl
drwxr-x--- 18 root root  303 Jan 10 13:41 share
```

This patch fixes the permissions of the CIVET install so "other" can access the files, allowing Singularity users to run the container.

WIP because my local build is still building.