### PR TITLE
Add CIVET base directory to path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=builder /opt/CIVET/Linux-x86_64/ /opt/CIVET/Linux-x86_64/
 # init.sh environment variables, should be equivalent to
 # printf "%s\n\n" "source /opt/CIVET/Linux-x86_64/init.sh" >> ~/.bashrc
 ENV MNIBASEPATH=/opt/CIVET/Linux-x86_64 CIVET=CIVET-2.1.1
-ENV PATH=$MNIBASEPATH/$CIVET/progs:$MNIBASEPATH/bin:$PATH \
+ENV PATH=$MNIBASEPATH/$CIVET:$MNIBASEPATH/$CIVET/progs:$MNIBASEPATH/bin:$PATH \
     LD_LIBRARY_PATH=$MNIBASEPATH/lib \
     MNI_DATAPATH=$MNIBASEPATH/share \
     PERL5LIB=$MNIBASEPATH/perl \


### PR DESCRIPTION
Currently CIVET_Processing_Pipeline is not in PATH.