### PR TITLE
Install locale in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04 as base
 RUN ["apt-get", "update", "-qq"]
-RUN ["apt-get", "install", "-qq", "perl", "imagemagick", "gnuplot"]
+RUN ["apt-get", "install", "-qq", "perl", "imagemagick", "gnuplot", "locales"]
 
 FROM base as builder
 RUN ["apt-get", "install", "-qq", "git-lfs"]


### PR DESCRIPTION
Running perl based packages currently throws a warning:
```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
```

Stolen from https://daten-und-bass.io/blog/fixing-missing-locale-setting-in-ubuntu-docker-image/