### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04 as base
 RUN ["apt-get", "update", "-qq"]
-RUN ["apt-get", "install", "-qq", "perl", "imagemagick", "gnuplot", "locales"]
+RUN ["apt-get", "install", "-qq", "--no-install-recommends", "perl", "imagemagick", "gnuplot-nox", "locales"]
 
 FROM base as builder
 RUN ["apt-get", "install", "-qq", "git-lfs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN ["tar", "-zxf", "TGZ/netpbm-10.35.94.tgz", "-C", "Linux-x86_64/SRC/"]
 COPY provision/netpbm/Makefile.config Linux-x86_64/SRC/netpbm-10.35.94
 
 RUN ["bash", "install.sh"]
+RUN ["bash", "job_test"]
 
 # clean up build files to reduce image size
 WORKDIR /opt/CIVET/Linux-x86_64


### PR DESCRIPTION
Two further improvements to dockerfile.

1. Slim down by using --no-install-recommends and gnuplot-nox.
2. Add running of the CIVET test suite so that future modifications to the build or Dockerfile get checked.