### PR TITLE
Add missing Helvetica font

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04 as base
 RUN ["apt-get", "update", "-qq"]
-RUN ["apt-get", "install", "-qq", "--no-install-recommends", "perl", "imagemagick", "gnuplot-nox", "locales"]
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+RUN ["apt-get", "install", "-qq", "--no-install-recommends", "perl", "imagemagick", "gnuplot-nox", "locales", "ttf-mscorefonts-installer"]
 
 FROM base as builder
 RUN ["apt-get", "install", "-qq", "git-lfs"]


### PR DESCRIPTION
Helvetica is hard-coded in the annotation call to imagemagick during QC image generation. Sadly it also seems that those stages aren't properly catching the error code of imagemagick and so this bug went unnoticed. Found when I starting running the container on data and found all the QC images don't have any text on them.

We need to install the named font Helvetica because imagemagick doesn't honour overrides in fontconfig to use another similar font.