### PR TITLE
make untar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,17 +934,21 @@ define make-untar-target
 	      cvs co -P -r ${$1_CVS_TAG} -d ${$1_DIR} ${$1_CVS} ; \
 	    else \
 	      if [ "$(USE_GIT)" == "yes" ] ; then \
-	        git lfs clone --recurse-submodules --branch ${$1_GIT_TAG} ${$1_GIT} ${$1_DIR}; \
-	        if [ ! -e ${$1_DIR}/.git ] ; then \
-	          echo "Fail to clone source codes from ${$1_GIT}"; \
-	          exit 1; \
-	        fi ; \
-	        cd ${$1_DIR}; \
-	        if [[ "`git describe --tags`" != "${$1_GIT_TAG}" ]] ; then \
-	          echo "Fail to checkout tag to ${$1_GIT_TAG}"; \
-	          exit 1; \
-	        fi ; \
-	        cd -; \
+          if [ -n "${$1_GIT}" ] ; then \
+            git lfs clone --recurse-submodules --branch ${$1_GIT_TAG} ${$1_GIT} ${$1_DIR}; \
+            if [ ! -e ${$1_DIR}/.git ] ; then \
+              echo "Fail to clone source codes from ${$1_GIT}"; \
+              exit 1; \
+            fi ; \
+            cd ${$1_DIR}; \
+            if [[ "`git describe --tags`" != "${$1_GIT_TAG}" ]] ; then \
+              echo "Fail to checkout tag to ${$1_GIT_TAG}"; \
+              exit 1; \
+            fi ; \
+            cd -; \
+          else \
+            echo "Warning: no git repo for $1" ; \
+          fi ; \
         else \
           echo "You need either USE_GIT=yes or USE_CVS=yes" ; \
           exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -1742,7 +1742,7 @@ surfreg       :  $(SURFREG)
 
 inits         :  ${ENV_FILES}
 
-untar         :  $(foreach element,$(LIST_TAR),$($(element)_UNTAR))
+untar         :  $(foreach element,$(LIST_ALL),$($(element)_UNTAR))
 utils         :  perllib getopt PMP ILT m4
 mnilibs       :  minc ebtks bicpl oobicpl
 models        :  adni avg305 colin27 icbm152 icbm152nl icbm152nl09

--- a/Makefile
+++ b/Makefile
@@ -945,6 +945,9 @@ define make-untar-target
 	          exit 1; \
 	        fi ; \
 	        cd -; \
+        else \
+          echo "You need either USE_GIT=yes or USE_CVS=yes" ; \
+          exit 1; \
 	      fi ; \
 	    fi ; \
 	  fi ; \

--- a/Makefile
+++ b/Makefile
@@ -1735,6 +1735,7 @@ surfreg       :  $(SURFREG)
 
 inits         :  ${ENV_FILES}
 
+untar         :  $(foreach element,$(LIST_TAR),$($(element)_UNTAR))
 utils         :  perllib getopt PMP ILT m4
 mnilibs       :  minc ebtks bicpl oobicpl
 models        :  adni avg305 colin27 icbm152 icbm152nl icbm152nl09

--- a/Makefile
+++ b/Makefile
@@ -934,24 +934,24 @@ define make-untar-target
 	      cvs co -P -r ${$1_CVS_TAG} -d ${$1_DIR} ${$1_CVS} ; \
 	    else \
 	      if [ "$(USE_GIT)" == "yes" ] ; then \
-          if [ -n "${$1_GIT}" ] ; then \
-            git lfs clone --recurse-submodules --branch ${$1_GIT_TAG} ${$1_GIT} ${$1_DIR}; \
-            if [ ! -e ${$1_DIR}/.git ] ; then \
-              echo "Fail to clone source codes from ${$1_GIT}"; \
-              exit 1; \
-            fi ; \
-            cd ${$1_DIR}; \
-            if [[ "`git describe --tags`" != "${$1_GIT_TAG}" ]] ; then \
-              echo "Fail to checkout tag to ${$1_GIT_TAG}"; \
-              exit 1; \
-            fi ; \
-            cd -; \
-          else \
-            echo "Warning: no git repo for $1" ; \
-          fi ; \
-        else \
-          echo "You need either USE_GIT=yes or USE_CVS=yes" ; \
-          exit 1; \
+	        if [ -n "${$1_GIT}" ] ; then \
+	          git lfs clone --recurse-submodules --branch ${$1_GIT_TAG} ${$1_GIT} ${$1_DIR}; \
+	          if [ ! -e ${$1_DIR}/.git ] ; then \
+	            echo "Fail to clone source codes from ${$1_GIT}"; \
+	            exit 1; \
+	          fi ; \
+	          cd ${$1_DIR}; \
+	          if [[ "`git describe --tags`" != "${$1_GIT_TAG}" ]] ; then \
+	            echo "Fail to checkout tag to ${$1_GIT_TAG}"; \
+	            exit 1; \
+	          fi ; \
+	          cd -; \
+	        else \
+	          echo "Warning: no git repo for $1" ; \
+	        fi ; \
+	      else \
+	        echo "You need either USE_GIT=yes or USE_CVS=yes" ; \
+	        exit 1; \
 	      fi ; \
 	    fi ; \
 	  fi ; \


### PR DESCRIPTION
### Introduction

https://github.com/aces/CIVET_Full_Project/blob/e831b1fc4b56d24a5caea775a201df85800f2739/Makefile#L12

The subcommand `make untar` was never implemented.

### Changes

I've added a line for the described functionality.

### Test
```
make USE_GIT=yes untar
```
### Motivation

it would be useful to have all sources preset from the get-go so that you can patch individual files for non-standard builds. e.g.

https://github.com/aces/CIVET_Full_Project/blob/e831b1fc4b56d24a5caea775a201df85800f2739/Dockerfile#L24-L26