### PR TITLE
Install libtext-format-perl to fix minchistory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04 as base
 RUN ["apt-get", "update", "-qq"]
-RUN ["apt-get", "install", "-qq", "--no-install-recommends", "perl", "imagemagick", "gnuplot-nox", "locales", "gsfonts"]
+RUN ["apt-get", "install", "-qq", "--no-install-recommends", "perl", "imagemagick", "gnuplot-nox", "locales", "gsfonts", "libtext-format-perl"]
 
 FROM base as builder
 RUN ["apt-get", "install", "-qq", "git-lfs"]


### PR DESCRIPTION
FIxes bug:

```
minchistory input.mnc 
Can't locate Text/Format.pm in @INC (you may need to install the Text::Format module) (@INC contains: /opt/CIVET/dist/perl /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.26.1 /usr/local/share/perl/5.26.1 /usr/lib/x86_64-linux-gnu/perl5/5.26 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.26 /usr/share/perl/5.26 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /opt/CIVET/dist/bin/minchistory line 20.
BEGIN failed--compilation aborted at /opt/CIVET/dist/bin/minchistory line 20.
```

`minchistory` requires an additional package `libtext-format-perl`

